### PR TITLE
Wait for registration callback before running commands

### DIFF
--- a/bin/nvl
+++ b/bin/nvl
@@ -1,22 +1,31 @@
 #!/usr/bin/env node
+/* global process */
 
 // Dependencies
 var cli = require('../index.js');
 var pkg = require('../package.json');
 var updateNotifier = require('update-notifier');
 
+// Initialize the CLI
+cli.initialize(function (err) {
+  if (err) {
+    console.log('Error initializing CLI')
+    console.log(err)
+    process.exit(1)
+  }
 
-// Check for update
-var notifier = updateNotifier({
-  packageName:         pkg.name,
-  packageVersion:      pkg.version,
-  updateCheckInterval: 1000 * 60 * 60 * 24 * 7
-});
+  // Check for update
+  var notifier = updateNotifier({
+    packageName:         pkg.name,
+    packageVersion:      pkg.version,
+    updateCheckInterval: 1000 * 60 * 60 * 24 * 7
+  });
 
-// Notify if update available
-if (notifier.update) {
-  notifier.notify();
-}
+  // Notify if update available
+  if (notifier.update) {
+    notifier.notify();
+  }
 
-// Run the command
-cli.run(process.argv);
+  // Run the command
+  cli.run(process.argv);
+})

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+/* global __dirname */
+
 /**
  * Dependencies
  */
@@ -23,33 +25,43 @@ cli.set({
 })
 
 /**
- * Initialize
+ * Register directories
+ *
  * Requires and registers a directory of plugins.
  */
 
-cli.initialize = function (directory) {
+cli.registerDirectories = function (directories, callback) {
   var plugins = []
-  var modules = fs.readdirSync(directory)
 
-  modules.forEach(function (mod) {
-    if (path.extname(mod) === '.js' && path.basename(mod) !== 'index.js') {
-      plugins.push({
-        register: require(path.join(directory, mod))
-      })
-    }
+  directories.forEach(function (directory) {
+    var modules = fs.readdirSync(directory)
+
+    modules.forEach(function (mod) {
+      if (path.extname(mod) === '.js' && path.basename(mod) !== 'index.js') {
+        plugins.push({
+          register: require(path.join(directory, mod))
+        })
+      }
+    })
   })
 
   cli.register(plugins, function (err) {
-    if (err) { }
+    callback(err)
   })
 }
 
 /**
- * Register Commands and Plugins
+ * Initialize
+ *
+ * Registers commands and plugins
  */
 
-cli.initialize(path.join(__dirname, 'lib', 'commands'))
-cli.initialize(path.join(__dirname, 'lib', 'plugins'))
+cli.initialize = function (callback) {
+  cli.registerDirectories([
+    path.join(__dirname, 'lib', 'commands'),
+    path.join(__dirname, 'lib', 'plugins')
+  ], callback)
+}
 
 /**
  * Exports


### PR DESCRIPTION
Fixes a race condition where CLI commands would not be registered by the time the CLI attempts to execute them.
