### PR TITLE
connect-cli #32 - Add redis logs to volume mappings for docker

### DIFF
--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -32,6 +32,7 @@ redis:
   image: anvilresearch/redis:<%= version %>
   volumes:
     - ./redis/data:/data
+    - ./redis/logs:/logs
   restart: always
   expose:
     - "6379"


### PR DESCRIPTION
Proposed fix for connect-cli #32 - added volume mapping for redis logs.  Did NOT pre-create the folder - looking at addressing that under #31 
