### PR TITLE
Allow updating clients to be untrusted

### DIFF
--- a/lib/commands/client.js
+++ b/lib/commands/client.js
@@ -392,7 +392,13 @@ function registerClient (cli, options, done) {
                   type: 'confirm',
                   name: 'trusted',
                   message: 'Will this be a trusted client?',
-                  value: (typeof (flags['trusted'] || flags.t) !== 'undefined') || undefined,
+                  value: function () {
+                    var trustedFlag = flags['trusted'] || flags.t
+                    if (typeof trustedFlag !== 'undefined') { return true }
+
+                    var untrustedFlag = flags['untrusted'] || flags.U
+                    if (typeof untrustedFlag !== 'undefined') { return false }
+                  },
                   default: client.trusted
                 },
                 {


### PR DESCRIPTION
Introduces `--untrusted` | `-U` flag for `client:update`
