### PR TITLE
fix: Added caCertPath to issuer config storage in setup.js

### DIFF
--- a/lib/commands/setup.js
+++ b/lib/commands/setup.js
@@ -151,7 +151,8 @@ function registerSetup (cli, options, done) {
                       issuer: issuerUri,
                       client_id: setup.client && setup.client.client_id,
                       client_secret: setup.client && setup.client.client_secret,
-                      redirect_uri: setup.client && setup.client.redirect_uris[0]
+                      redirect_uri: setup.client && setup.client.redirect_uris[0],
+                      caCertPath: caCertPath && path.resolve(caCertPath)
                     })
                   } catch (e) {
                     cli.log.error('Couldn\'t write configuration file')


### PR DESCRIPTION
This should fix a problem where one can use `nvl setup` but not login afterwards due to certificate errors.
