### PR TITLE
Avoid YAML dump error by skipping undefined properties

### DIFF
--- a/lib/plugins/yaml.js
+++ b/lib/plugins/yaml.js
@@ -12,10 +12,18 @@ function registerYAML (cli, options, done) {
   cli.fs.registerSerializer('yaml', function (obj, opts) {
     opts = opts || {}
 
+    var copy = {}
+
+    Object.getOwnPropertyNames(obj).forEach(function (prop) {
+      if (typeof obj[prop] !== 'undefined') {
+        copy[prop] = obj[prop]
+      }
+    })
+
     if (opts.unsafe) {
-      return yaml.dump(obj, opts)
+      return yaml.dump(copy, opts)
     } else {
-      return yaml.safeDump(obj, opts)
+      return yaml.safeDump(copy, opts)
     }
   })
 


### PR DESCRIPTION
Properties with a value of undefined may cause the serializer to throw an error, which is undesirable. This code skips any undefined properties before attempting to serialize the incoming object YAML.
