### PR TITLE
Use version of Node.js unaffected by CVE-2015-7384

### DIFF
--- a/templates/connect/Dockerfile
+++ b/templates/connect/Dockerfile
@@ -4,7 +4,7 @@
 # https://github.com/anvilresearch/connect
 #
 
-FROM mhart/alpine-node:4.1.0
+FROM mhart/alpine-node:4.2.0
 
 # Define working dir
 WORKDIR /opt/connect


### PR DESCRIPTION
Details at https://github.com/nodejs/node/issues/3138

v4.2.0 is also an LTS version (30 months of support)
