### PR TITLE
Gracefully terminate server on SIGTERM

### DIFF
--- a/templates/connect/server.js
+++ b/templates/connect/server.js
@@ -30,3 +30,10 @@ if (cluster.isMaster) {
 cluster.on('exit', function (worker) {
   cluster.fork()
 })
+
+/**
+ * Respond to SIGTERM by gracefully terminating server
+ */
+process.on('SIGTERM', function () {
+  process.exit()
+})


### PR DESCRIPTION
This fixes an issue, first observed in Docker, where Anvil Connect would hang upon a `docker stop` command.

`docker stop` issues a SIGTERM interrupt to all processes and waits for a certain amount of time before finally issuing a SIGKILL. Because the server would not respond to the SIGTERM interrupt, the time would elapse, at which point the process would finally be killed. This caused significant issues with responsiveness, and the process would not have a chance to gracefully terminate.

This change listens for SIGTERM, and then runs `process.exit()` to gracefully terminate the running process.
