### PR TITLE
Make openssl available in Docker environment

### DIFF
--- a/templates/connect/Dockerfile
+++ b/templates/connect/Dockerfile
@@ -14,7 +14,7 @@ COPY ./package.json /opt/connect/package.json
 COPY ./server.js /opt/connect/server.js
 
 # Install npm package
-RUN apk add --update python make alpine-sdk && \
+RUN apk add --update python make alpine-sdk openssl && \
     npm install --production && \
     apk del python make alpine-sdk && \
     rm /var/cache/apk/* && \


### PR DESCRIPTION
Anvil Connect requires openssl to be present on the system in order to generate keypairs.

alpine-sdk installs openssl, but it is deleted further on in the RUN script when alpine-sdk is uninstalled.

Explicitly requesting the installation of the openssl package up front prevents its removal when alpine-sdk is uninstalled.
