### PR TITLE
Respect Redis configuration file

### DIFF
--- a/templates/redis/Dockerfile
+++ b/templates/redis/Dockerfile
@@ -27,4 +27,4 @@ VOLUME ["/data", "/logs"]
 WORKDIR /data
 
 # Define default command
-CMD [ "redis-server" ]
+CMD [ "redis-server", "/etc/redis.conf" ]

--- a/templates/redis/etc/redis.conf
+++ b/templates/redis/etc/redis.conf
@@ -34,7 +34,7 @@
 
 # By default Redis does not run as a daemon. Use 'yes' if you need it.
 # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
-daemonize yes
+daemonize no
 
 # When running daemonized, Redis writes a pid file in /var/run/redis.pid by
 # default. You can specify a custom pid file location here.

--- a/templates/redis/etc/redis.conf
+++ b/templates/redis/etc/redis.conf
@@ -100,7 +100,7 @@ loglevel notice
 # Specify the log file name. Also the empty string can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile /var/log/redis/redis.log
+logfile /logs/redis.log
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.
@@ -184,7 +184,7 @@ dbfilename dump.rdb
 # The Append Only File will also be created inside this directory.
 #
 # Note that you must specify a directory here, not a file name.
-dir /var/lib/redis/
+dir /data
 
 ################################# REPLICATION #################################
 

--- a/templates/redis/etc/redis.conf
+++ b/templates/redis/etc/redis.conf
@@ -936,5 +936,4 @@ hz 10
 # in order to commit the file to the disk more incrementally and avoid
 # big latency spikes.
 aof-rewrite-incremental-fsync yes
-include /etc/redis-local.conf
 


### PR DESCRIPTION
Prior to this change, Redis ran with defaults and did not respect the configuration file.
